### PR TITLE
Fix contract data mismatch for NFT contract issue function

### DIFF
--- a/doc/smart_contract/NFT_contract.md
+++ b/doc/smart_contract/NFT_contract.md
@@ -2,6 +2,7 @@
 
 - [NFT Contract](#nft-contract)
   - [Register](#register)
+  - [Create an Instance for an Existing NFT Contract](#create-an-instance-for-an-existing-nft-contract)
   - [Issue](#issue)
 
 
@@ -23,6 +24,24 @@ Example output
 
 ```
 CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN
+```
+
+## Create an Instance for an Existing NFT Contract 
+```python
+import py_v_sdk as pv
+import py_v_sdk.contract.nft_ctrt as nft_ctrt
+
+# chain: pv.Chain
+# acnt: pv.Account
+
+# An example NFT contract id
+# ctrt_id = "CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN"
+
+# Create a representative instance for an existing NFT contract
+nc = nft_ctrt.NFTCtrt(
+  pv.B58Str(ctrt_id),
+  chain,
+)
 ```
 
 ## Issue

--- a/doc/smart_contract/NFT_contract.md
+++ b/doc/smart_contract/NFT_contract.md
@@ -6,14 +6,23 @@
 
 
 ## Register
-The sample codes below show how to register an NFT contract.
 
 ```python
+import py_v_sdk as pv
 import py_v_sdk.contract.nft_ctrt as nft_ctrt
 
-acnt = pv.Account(chain, seed)
+# chain: pv.Chain
+# seed: str
+# acnt: pv.Account
+
+# Register a new NFT contract
 nc = nft_ctrt.NFTCtrt.register(by=acnt)
-print(nc.ctrt_id)
+print(nc.ctrt_id.data) # print the id of the newly registered contract
+```
+Example output
+
+```
+CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN
 ```
 
 ## Issue

--- a/doc/smart_contract/NFT_contract.md
+++ b/doc/smart_contract/NFT_contract.md
@@ -45,4 +45,18 @@ nc = nft_ctrt.NFTCtrt(
 ```
 
 ## Issue
-(Will be completed soon)
+
+```python
+import py_v_sdk as pv
+import py_v_sdk.contract.nft_ctrt as nft_ctrt
+
+# nc: nft_ctrt.NFTCtrt
+
+resp = nc.issue(by=acnt)
+print(resp)
+```
+
+Example output
+```
+{'type': 9, 'id': 'DyFKAkv6xSWuPjau3k8YXoPG4Awk2DL1iCK62Tch8k9u', 'fee': 30000000, 'feeScale': 100, 'timestamp': 1642064271931793920, 'proofs': [{'proofType': 'Curve25519', 'publicKey': '6gmM7UxzUyRJXidy2DpXXMvrPqEF9hR1eAqsmh33J6eL', 'address': 'AU6BNRK34SLuc27evpzJbAswB6ntHV2hmjD', 'signature': '5bVP3Krrddg8Z5J2XDcKb8MHfjqdhhFH6S3rh1pnj2wJde8YsatkBLHhyUs5f4LgqJHKK1zYVaUpdzF5Py2xUS27'}], 'contractId': 'CEvfK7Jw8ZxnbxZjEW8Ejumco5u4YSDKbYi', 'functionIndex': 1, 'functionData': '12Wfh1', 'attachment': ''}
+```

--- a/py_v_sdk/account.py
+++ b/py_v_sdk/account.py
@@ -19,7 +19,9 @@ class Account:
         self._nonce = nonce
         self._acnt_seed_hash = self.get_acnt_seed_hash(seed, nonce)
         self._key_pair = self.get_key_pair(self._acnt_seed_hash)
-        self._addr = self.get_addr(self.key_pair.pub, self.ADDR_VER, self.chain.chain_id)
+        self._addr = self.get_addr(
+            self.key_pair.pub, self.ADDR_VER, self.chain.chain_id
+        )
 
     @property
     def chain(self) -> ch.Chain:
@@ -40,11 +42,11 @@ class Account:
     @property
     def acnt_seed_hash(self) -> md.Bytes:
         return self._acnt_seed_hash
-    
+
     @property
     def key_pair(self) -> md.KeyPair:
         return self._key_pair
-    
+
     @property
     def addr(self) -> md.Bytes:
         return self._addr
@@ -52,7 +54,9 @@ class Account:
     @staticmethod
     def get_acnt_seed_hash(seed: str, nonce: int) -> md.Bytes:
         return md.Bytes(
-            hs.sha256_hash(hs.keccak256_hash(hs.blake2b_hash(bu.str_to_bytes(f"{nonce}{seed}"))))
+            hs.sha256_hash(
+                hs.keccak256_hash(hs.blake2b_hash(bu.str_to_bytes(f"{nonce}{seed}")))
+            )
         )
 
     @staticmethod
@@ -71,27 +75,23 @@ class Account:
             return hs.keccak256_hash(hs.blake2b_hash(b))
 
         raw_addr: str = (
-            chr(addr_ver)
-            + chain_id.value
-            + bu.bytes_to_str(hash(pub_key.bytes))[:20]
+            chr(addr_ver) + chain_id.value + bu.bytes_to_str(hash(pub_key.bytes))[:20]
         )
 
-        addr_hash: str = bu.bytes_to_str(
-            hash(
-                bu.str_to_bytes(raw_addr)
-            )
-        )[:4]
+        addr_hash: str = bu.bytes_to_str(hash(bu.str_to_bytes(raw_addr)))[:4]
 
-        return md.Bytes(
-            bu.str_to_bytes(raw_addr + addr_hash)
-        )
-    
+        return md.Bytes(bu.str_to_bytes(raw_addr + addr_hash))
+
     @property
     def balance(self) -> int:
         return self.api.addr.get_balance(self.addr.b58_str)["balance"]
 
     def register_contract(self, req: tx.RegCtrtTxReq) -> Dict[str, Any]:
-        return self.api.ctrt.broadcast_register(req.to_broadcast_register_payload(self.key_pair))
+        return self.api.ctrt.broadcast_register(
+            req.to_broadcast_register_payload(self.key_pair)
+        )
 
     def execute_contract(self, req: tx.ExecCtrtFuncTxReq) -> Dict[str, Any]:
-        return self.api.ctrt.broadcast_execute(req.to_broadcast_execute_payload(self.key_pair))
+        return self.api.ctrt.broadcast_execute(
+            req.to_broadcast_execute_payload(self.key_pair)
+        )

--- a/py_v_sdk/api.py
+++ b/py_v_sdk/api.py
@@ -26,7 +26,7 @@ class NodeAPI:
     @property
     def host(self) -> str:
         return self.host
-    
+
     @property
     def blocks(self) -> "Blocks":
         return self._blocks
@@ -34,7 +34,7 @@ class NodeAPI:
     @property
     def node(self) -> "Node":
         return self._node
-    
+
     @property
     def ctrt(self) -> "Contract":
         return self._ctrt
@@ -68,7 +68,7 @@ class Blocks(APIGrp):
 
     def get_height(self) -> Dict[str, Any]:
         return self.get("/height")
-    
+
     def get_last_block(self) -> Dict[str, Any]:
         return self.get("/last")
 

--- a/py_v_sdk/contract/__init__.py
+++ b/py_v_sdk/contract/__init__.py
@@ -176,16 +176,16 @@ class CtrtMeta:
         stmap_bytes = (
             b""
             if self.lang_ver.data == 1
-            else self.state_map.serialize(True, True).bytes
+            else self.state_map.serialize().bytes
         )
         b = (
             self.lang_code.serialize().bytes
             + self.lang_ver.serialize().bytes
-            + self.triggers.serialize(True, True).bytes
-            + self.descriptors.serialize(True, True).bytes
-            + self.state_vars.serialize(True, True).bytes
+            + self.triggers.serialize().bytes
+            + self.descriptors.serialize().bytes
+            + self.state_vars.serialize().bytes
             + stmap_bytes
-            + self.textual.serialize(with_items_len=True).bytes
+            + self.textual.serialize(with_bytes_len=False).bytes
         )
         return md.Bytes(b)
 

--- a/py_v_sdk/contract/__init__.py
+++ b/py_v_sdk/contract/__init__.py
@@ -174,9 +174,7 @@ class CtrtMeta:
             bytes: The serialized bytes string
         """
         stmap_bytes = (
-            b""
-            if self.lang_ver.data == 1
-            else self.state_map.serialize().bytes
+            b"" if self.lang_ver.data == 1 else self.state_map.serialize().bytes
         )
         b = (
             self.lang_code.serialize().bytes
@@ -241,8 +239,7 @@ class Contract(abc.ABC):
     @property
     def ctrt_id(self) -> md.B58Str:
         return self._ctrt_id
-    
+
     @property
     def chain(self) -> ch.Chain:
         return self._chain
-    

--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -42,7 +42,7 @@ class NFTCtrt(Contract):
     def register(cls, by: acnt.Account) -> "NFTCtrt":
         data = by.register_contract(
             tx_req.RegCtrtTxReq(
-                data_stack=md.DataEntries.default(),
+                data_stack=md.DataStack.default(),
                 ctrt_meta=cls.CTRT_META,
                 timestamp=md.Timestamp.now(),
             )
@@ -77,7 +77,7 @@ class NFTCtrt(Contract):
             tx_req.ExecCtrtFuncTxReq(
                 ctrt_id=self.ctrt_id,
                 func_id=self.FuncIdx.ISSUE,
-                data_stack=md.DataEntries([
+                data_stack=md.DataStack([
                     md.String(description),
                 ]),
                 timestamp=md.Timestamp.now(),

--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -77,9 +77,11 @@ class NFTCtrt(Contract):
             tx_req.ExecCtrtFuncTxReq(
                 ctrt_id=self.ctrt_id,
                 func_id=self.FuncIdx.ISSUE,
-                data_stack=md.DataStack([
-                    md.String(description),
-                ]),
+                data_stack=md.DataStack(
+                    [
+                        md.String(description),
+                    ]
+                ),
                 timestamp=md.Timestamp.now(),
                 attachment=md.String(description),
             )

--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -44,7 +44,7 @@ class NFTCtrt(Contract):
             tx_req.RegCtrtTxReq(
                 data_stack=md.DataEntries.default(),
                 ctrt_meta=cls.CTRT_META,
-                timestamp=md.Timestamp.default(),
+                timestamp=md.Timestamp.now(),
             )
         )
         logger.debug(data)
@@ -80,7 +80,7 @@ class NFTCtrt(Contract):
                 data_stack=md.DataEntries([
                     md.String(description),
                 ]),
-                timestamp=md.Timestamp.default(),
+                timestamp=md.Timestamp.now(),
                 attachment=md.String(description),
             )
         )

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -2,7 +2,7 @@ import abc
 import struct
 import copy
 import time
-from typing import List, Type, NamedTuple
+from typing import List, Type, NamedTuple, Optional
 
 import base58
 

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -478,6 +478,17 @@ class BytesList(DataEntries):
         """
         return [i.b58_str for i in self.items]
 
+    def serialize(self, with_items_len: bool = True, with_bytes_len: bool = True) -> "Bytes":
+        return super().serialize(
+            with_items_len,
+            with_bytes_len,
+            **{
+                "with_size": True,
+                "with_idx": False,
+            },
+        )
+
+
 class Bool(DataEntry):
     """
     Bool is the data container for a boolean value

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -79,20 +79,27 @@ class DataEntry(abc.ABC):
         """
         raise NotImplementedError
 
-    def serialize(self, with_size: bool = False) -> "Bytes":
+    def serialize(self, with_size: bool = False, with_idx: bool = False) -> "Bytes":
         """
         serialize serializes the holding data to bytes
         if with_size == True, prefix bytes for the length will be prepended
+        if with_idx == True, prefix bytes for the index will be prepended
 
         Args:
-            with_size (bool, optional): Whether or not prepend size bytes. Defaults to False.
+            with_size (bool, optional): Whether or not to prepend size bytes. Defaults to False
+            with_idx (bool, optional): Whether or not to prepend idx bytes. Defaults to False
 
         Returns:
             Bytes: The serialization result
         """
         b = self.bytes
+
         if with_size:
             b = struct.pack(">H", len(b)) + b
+
+        if with_idx:
+            b = UnChar(self.IDX).bytes + b
+
         return Bytes(b)
 
 

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -164,8 +164,10 @@ class DataEntries:
         return cls(items)
 
     def serialize(
-        self, with_items_len: bool = False, with_bytes_len: bool = False,
-        **item_serial_args
+        self,
+        with_items_len: bool = False,
+        with_bytes_len: bool = False,
+        **item_serial_args,
     ) -> "Bytes":
         """
         serialize serializes the holding DataEntry items to bytes
@@ -174,7 +176,7 @@ class DataEntries:
             with_items_len (bool, optional): Whether or not to prepend size bytes for the amount of items. Defaults to False.
             with_bytes_len (bool, optional): Whether or not to prepend size bytes for the length of bytes. Defaults to False.
 
-        Kwargs: 
+        Kwargs:
             item_serial_args (Dict[str, Any]): Keyword arguments for the serialize method of items
 
         Returns:
@@ -207,6 +209,7 @@ class UnChar(Integer):
     """
     UnChar is the data container for unsigned char integer (1 byte)
     """
+
     @classmethod
     def from_bytes(cls, b: bytes) -> "UnChar":
         return cls(struct.unpack(">B", b)[0])
@@ -311,7 +314,8 @@ class Timestamp(UnLongLong):
 class Amount(UnLongLong):
     """
     Amount is the data container for amount
-    """    
+    """
+
     IDX = 3
 
 
@@ -319,6 +323,7 @@ class Balance(UnLongLong):
     """
     Balance is the data container for account balance
     """
+
     IDX = 12
 
 
@@ -376,7 +381,7 @@ class B58Str(String):
     def from_bytes(cls, b: bytes) -> "String":
         b = base58.b58encode(b)
         return cls(bu.bytes_to_str(b))
-    
+
     @property
     def bytes(self) -> bytes:
         return base58.b58decode(self.data)
@@ -386,13 +391,15 @@ class PubKey(B58Str):
     """
     PubKey is the data container for Public Key in base58 string format
     """
+
     IDX = 1
 
 
 class Addr(B58Str):
     """
     Addr is the data container for Address in base58 string format
-    """    
+    """
+
     IDX = 2
 
 
@@ -400,6 +407,7 @@ class CtrtAcnt(B58Str):
     """
     CtrtAcnt is the data container for Contract Account
     """
+
     IDX = 6
 
 
@@ -407,6 +415,7 @@ class Acnt(B58Str):
     """
     Acnt is the data container for Account
     """
+
     IDX = 7
 
 
@@ -414,6 +423,7 @@ class TokenID(B58Str):
     """
     TokenID is the data container for Token ID
     """
+
     IDX = 8
 
 
@@ -479,7 +489,9 @@ class BytesList(DataEntries):
         """
         return [i.b58_str for i in self.items]
 
-    def serialize(self, with_items_len: bool = True, with_bytes_len: bool = True) -> "Bytes":
+    def serialize(
+        self, with_items_len: bool = True, with_bytes_len: bool = True
+    ) -> "Bytes":
         return super().serialize(
             with_items_len,
             with_bytes_len,
@@ -496,7 +508,9 @@ class DataStack(DataEntries):
     has non-zero index(IDX)
     """
 
-    def serialize(self, with_items_len: bool = True, with_bytes_len: bool = True) -> "Bytes":
+    def serialize(
+        self, with_items_len: bool = True, with_bytes_len: bool = True
+    ) -> "Bytes":
         return super().serialize(
             with_items_len,
             with_bytes_len,
@@ -511,6 +525,7 @@ class Bool(DataEntry):
     """
     Bool is the data container for a boolean value
     """
+
     IDX = 10
 
 
@@ -518,5 +533,6 @@ class KeyPair(NamedTuple):
     """
     KeyPair is the data container for an asymmetric key pair
     """
+
     pub: Bytes
     pri: Bytes

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -489,6 +489,23 @@ class BytesList(DataEntries):
         )
 
 
+class DataStack(DataEntries):
+    """
+    DataStack is a special case of DataEntries where all internal DataEntry(s)
+    has non-zero index(IDX)
+    """
+
+    def serialize(self, with_items_len: bool = True, with_bytes_len: bool = True) -> "Bytes":
+        return super().serialize(
+            with_items_len,
+            with_bytes_len,
+            **{
+                "with_size": True,
+                "with_idx": True,
+            },
+        )
+
+
 class Bool(DataEntry):
     """
     Bool is the data container for a boolean value

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -14,6 +14,8 @@ class DataEntry(abc.ABC):
     DataEntry is the abstract base class for customized data containers
     """
 
+    IDX = 0
+
     @classmethod
     @abc.abstractmethod
     def from_bytes(cls, b: bytes) -> "DataEntry":
@@ -230,6 +232,8 @@ class UnInt(Integer):
     UnInt is the data container for unsinged integer (4 bytes)
     """
 
+    IDX = 4
+
     @classmethod
     def from_bytes(cls, b: bytes) -> "UnInt":
         return cls(struct.unpack(">I", b)[0])
@@ -272,6 +276,8 @@ class Timestamp(UnLongLong):
     To avoid floating point, a second is stored as 1_000_000_000
     """
 
+    IDX = 9
+
     @classmethod
     def now(cls) -> "Timestamp":
         """
@@ -291,6 +297,8 @@ class String(DataEntry):
     """
     String is the data container for string
     """
+
+    IDX = 5
 
     def __init__(self, data: str = ""):
         self.data = data
@@ -349,6 +357,8 @@ class Bytes(DataEntry):
     """
     Bytes is the data container for bytes
     """
+
+    IDX = 11
 
     def __init__(self, data: bytes = b"") -> None:
         self.data = data

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -164,24 +164,29 @@ class DataEntries:
         return cls(items)
 
     def serialize(
-        self, with_items_len: bool = False, with_bytes_len: bool = False
+        self, with_items_len: bool = False, with_bytes_len: bool = False,
+        **item_serial_args
     ) -> "Bytes":
         """
         serialize serializes the holding DataEntry items to bytes
 
         Args:
-            with_items_len (bool, optional): Whether or not to prepend size bytes for the length of items. Defaults to False.
+            with_items_len (bool, optional): Whether or not to prepend size bytes for the amount of items. Defaults to False.
             with_bytes_len (bool, optional): Whether or not to prepend size bytes for the length of bytes. Defaults to False.
 
+        Kwargs: 
+            item_serial_args (Dict[str, Any]): Keyword arguments for the serialize method of items
+
         Returns:
-            [type]: [description]
+            Bytes: The serialization result
         """
+
         b = b""
         if with_items_len:
             b = struct.pack(">H", len(self.items)) + b
 
         for i in self.items:
-            b += i.serialize(with_size=True).bytes
+            b += i.serialize(**item_serial_args).bytes
 
         if with_bytes_len:
             b = struct.pack(">H", len(b)) + b

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -293,6 +293,20 @@ class Timestamp(UnLongLong):
         return cls.now()
 
 
+class Amount(UnLongLong):
+    """
+    Amount is the data container for amount
+    """    
+    IDX = 3
+
+
+class Balance(UnLongLong):
+    """
+    Balance is the data container for account balance
+    """
+    IDX = 12
+
+
 class String(DataEntry):
     """
     String is the data container for string
@@ -351,6 +365,41 @@ class B58Str(String):
     @property
     def bytes(self) -> bytes:
         return base58.b58decode(self.data)
+
+
+class PubKey(B58Str):
+    """
+    PubKey is the data container for Public Key in base58 string format
+    """
+    IDX = 1
+
+
+class Addr(B58Str):
+    """
+    Addr is the data container for Address in base58 string format
+    """    
+    IDX = 2
+
+
+class CtrtAcnt(B58Str):
+    """
+    CtrtAcnt is the data container for Contract Account
+    """
+    IDX = 6
+
+
+class Acnt(B58Str):
+    """
+    Acnt is the data container for Account
+    """
+    IDX = 7
+
+
+class TokenID(B58Str):
+    """
+    TokenID is the data container for Token ID
+    """
+    IDX = 8
 
 
 class Bytes(DataEntry):
@@ -413,6 +462,12 @@ class BytesList(DataEntries):
             List[str]: The list of base58-encoded string representation
         """
         return [i.b58_str for i in self.items]
+
+class Bool(DataEntry):
+    """
+    Bool is the data container for a boolean value
+    """
+    IDX = 10
 
 
 class KeyPair(NamedTuple):

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -108,7 +108,10 @@ class DataEntries:
     DataEntries is the collection class for DataEntry
     """
 
-    def __init__(self, items: List[DataEntry] = []) -> None:
+    def __init__(self, items: Optional[List[DataEntry]] = None) -> None:
+        if items is None:
+            self.items = []
+        else:
         self.items = copy.deepcopy(items)
 
     @classmethod

--- a/py_v_sdk/model.py
+++ b/py_v_sdk/model.py
@@ -112,7 +112,7 @@ class DataEntries:
         if items is None:
             self.items = []
         else:
-        self.items = copy.deepcopy(items)
+            self.items = copy.deepcopy(items)
 
     @classmethod
     def default(cls) -> "DataEntries":
@@ -299,7 +299,7 @@ class Timestamp(UnLongLong):
         now returns the Timestamp with the current unix timestamp
 
         Returns:
-            [type]: [description]
+            Timestamp: The current Timestamp
         """
         return cls(int(time.time() * 1_000_000_000))
 
@@ -449,7 +449,8 @@ class Bytes(DataEntry):
 
 class BytesList(DataEntries):
     """
-    BytesList is the collection class for Bytes
+    BytesList is a special case of DataEntries where all internal DataEntry(s)
+    are Bytes
     """
 
     @classmethod
@@ -514,5 +515,8 @@ class Bool(DataEntry):
 
 
 class KeyPair(NamedTuple):
+    """
+    KeyPair is the data container for an asymmetric key pair
+    """
     pub: Bytes
     pri: Bytes

--- a/py_v_sdk/tx_req.py
+++ b/py_v_sdk/tx_req.py
@@ -1,6 +1,5 @@
 import abc
 import enum
-import struct
 from typing import Dict, Any
 
 from py_v_sdk import model as md
@@ -73,7 +72,7 @@ class RegCtrtTxReq(TxReq):
 
     def __init__(
         self,
-        data_stack: md.DataEntries,
+        data_stack: md.DataStack,
         ctrt_meta: ctrt.CtrtMeta,
         timestamp: md.Timestamp,
         description: md.String = md.String.default(),
@@ -82,7 +81,7 @@ class RegCtrtTxReq(TxReq):
     ) -> None:
         """
         Args:
-            data_stack (md.DataEntries): The payload of this request
+            data_stack (md.DataStack): The payload of this request
             ctrt_meta (ctrt.CtrtMeta): The meta data of the contract to register
             timestamp (md.Timestamp): The timestamp of this request
             description (md.String, optional): The description for this request. Defaults to md.String.default().
@@ -100,8 +99,8 @@ class RegCtrtTxReq(TxReq):
     def data_to_sign(self) -> md.Bytes:
         b = (
             self.TX_TYPE.serialize().bytes
-            + self.ctrt_meta.serialize().serialize(True).bytes
-            + self.data_stack.serialize(True, True).bytes
+            + self.ctrt_meta.serialize().serialize(with_size=True).bytes
+            + self.data_stack.serialize().bytes
             + self.description.serialize_with_str_size().bytes
             + self.fee.bytes
             + self.fee_scale.bytes
@@ -122,7 +121,7 @@ class RegCtrtTxReq(TxReq):
         return {
             "senderPublicKey": key_pair.pub.b58_str,
             "contract": self.ctrt_meta.serialize().b58_str,
-            "initData": self.data_stack.serialize(with_items_len=True).b58_str,
+            "initData": self.data_stack.serialize(with_bytes_len=False).b58_str,
             "description": self.description.data,
             "fee": self.fee.data,
             "feeScale": self.fee_scale.data,
@@ -143,7 +142,7 @@ class ExecCtrtFuncTxReq(TxReq):
         self,
         ctrt_id: md.B58Str,
         func_id: ctrt.Contract.FuncIdx,
-        data_stack: md.DataEntries,
+        data_stack: md.DataStack,
         timestamp: md.Timestamp,
         attachment: md.String = md.String.default(),
         fee: md.TxFee = TX_FEE,
@@ -153,7 +152,7 @@ class ExecCtrtFuncTxReq(TxReq):
         Args:
             ctrt_id (md.B58Str): The contract id
             func_id (ctrt.Contract.FuncIdx): The function index
-            data_stack (md.DataEntries): The payload of this request
+            data_stack (md.DataStack): The payload of this request
             timestamp (md.Timestamp): The timestamp of this request
             attachment (md.String, optional): The attachment for this request. Defaults to md.String.default().
             fee (md.TxFee, optional): The fee for this request. Defaults to TX_FEE.
@@ -173,7 +172,7 @@ class ExecCtrtFuncTxReq(TxReq):
             self.TX_TYPE.serialize().bytes
             + self.ctrt_id.bytes
             + md.UnShort(self.func_id.value).bytes
-            + self.data_stack.serialize(True, True).bytes
+            + self.data_stack.serialize().bytes
             + self.attachment.serialize_with_str_size().bytes
             + self.fee.bytes
             + self.fee_scale.bytes
@@ -195,7 +194,7 @@ class ExecCtrtFuncTxReq(TxReq):
             "senderPublicKey": key_pair.pub.b58_str,
             "contractId": self.ctrt_id.data,
             "functionIndex": self.func_id.value,
-            "functionData": self.data_stack.serialize(with_items_len=True).b58_str,
+            "functionData": self.data_stack.serialize(with_bytes_len=False).b58_str,
             "attachment": self.attachment.b58_str,
             "fee": self.fee.data,
             "feeScale": self.fee_scale.data,

--- a/py_v_sdk/tx_req.py
+++ b/py_v_sdk/tx_req.py
@@ -165,7 +165,7 @@ class ExecCtrtFuncTxReq(TxReq):
         self.attachment = attachment
         self.fee = fee
         self.fee_scale = fee_scale
-    
+
     @property
     def data_to_sign(self) -> md.Bytes:
         b = (
@@ -189,7 +189,7 @@ class ExecCtrtFuncTxReq(TxReq):
 
         Returns:
             Dict[str, Any]: The payload
-        """        
+        """
         return {
             "senderPublicKey": key_pair.pub.b58_str,
             "contractId": self.ctrt_id.data,

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ setuptools.setup(
     author_email="developers@v.systems",
     license="MIT",
     packages=setuptools.find_packages(),
-    install_requires=["requests~=2.27.1", "python-axolotl-curve25519~=0.4.1.post2", "base58~=2.1.1", "loguru~=0.5.3"],
+    install_requires=[
+        "requests~=2.27.1",
+        "python-axolotl-curve25519~=0.4.1.post2",
+        "base58~=2.1.1",
+        "loguru~=0.5.3",
+    ],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
This PR fixes the issue where the `contract data mismatch` error occurs while calling the `issue` function of the NFT contract.