### PR TITLE
📃 docs: add branch name for pip install from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ The official Python SDK for VSYS APIs. The [old Python SDK](https://github.com/v
 > Will be published to PYPI soon
 
 ```bash
-pip install git+https://github.com/virtualeconomy/py-v-sdk.git
+pip install git+https://github.com/virtualeconomy/py-v-sdk.git@main
 ```
+
+`@mian` is necessary as the default branch is `develop`
 
 If you are using `pipenv`, try
 
 ```bash
-pipenv install git+https://github.com/virtualeconomy/py-v-sdk.git#egg=py_v_sdk
+pipenv install git+https://github.com/virtualeconomy/py-v-sdk.git@main#egg=py_v_sdk
 ```
 
 


### PR DESCRIPTION
## What Does This PR Do

  - Specifies the installing branch as `main` for pip installing from Github