### PR TITLE
🦄 refactor: shorten the import path of contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ chain: pv.Chain = pv.Chain(api)
 # Account represents an account in the net
 acnt: pv.Account = pv.Account(chain, WALLET_SEED)
 
+ctrt_id = "CFB6zvcy39FCRGhxo8HH3PE6zZEG5zXevhG"
+ctrt: pv.NFTCtrt = pv.NFTCtrt(ctrt_id, chain)
+
 
 def try_api():
     # GET /blocks/last
@@ -76,16 +79,23 @@ def try_acnt():
     # Get the account's nonce'
     print(acnt.nonce)
     # Get the account's public key
-    print(acnt.key_pair.pub.b58_str)
+    print(acnt.key_pair.pub_b58_str)
     # Get the account's private key
-    print(acnt.key_pair.pri.b58_str)
+    print(acnt.key_pair.pri_b58_str)
     # Get the account's address
-    print(acnt.addr.b58_str)
+    print(acnt.addr_b58_str)
+
+
+def try_ctrt():
+  print(ctrt.maker)
+  print(ctrt.issuer)
+  print(ctrt.ctrt_id)
 
 
 try_api()
 try_chain()
 try_acnt()
+try_ctrt()
 ```
 
 

--- a/doc/smart_contract/NFT_contract.md
+++ b/doc/smart_contract/NFT_contract.md
@@ -10,15 +10,12 @@
 
 ```python
 import py_v_sdk as pv
-import py_v_sdk.contract.nft_ctrt as nft_ctrt
 
-# chain: pv.Chain
-# seed: str
 # acnt: pv.Account
 
 # Register a new NFT contract
-nc = nft_ctrt.NFTCtrt.register(by=acnt)
-print(nc.ctrt_id.data) # print the id of the newly registered contract
+nc = pv.NFTCtrt.register(by=acnt)
+print(nc.ctrt_id) # print the id of the newly registered contract
 ```
 Example output
 
@@ -29,28 +26,23 @@ CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN
 ## Create an Instance for an Existing NFT Contract 
 ```python
 import py_v_sdk as pv
-import py_v_sdk.contract.nft_ctrt as nft_ctrt
 
 # chain: pv.Chain
-# acnt: pv.Account
 
 # An example NFT contract id
-# ctrt_id = "CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN"
+ctrt_id = "CF6jEF52DZgn8qjQL2oYdvUT34fgHyU4PWN"
 
 # Create a representative instance for an existing NFT contract
-nc = nft_ctrt.NFTCtrt(
-  pv.B58Str(ctrt_id),
-  chain,
-)
+nc = pv.NFTCtrt(ctrt_id, chain)
 ```
 
 ## Issue
 
 ```python
 import py_v_sdk as pv
-import py_v_sdk.contract.nft_ctrt as nft_ctrt
 
-# nc: nft_ctrt.NFTCtrt
+# acnt: pv.Account
+# nc: pv.NFTCtrt
 
 resp = nc.issue(by=acnt)
 print(resp)

--- a/py_v_sdk/__init__.py
+++ b/py_v_sdk/__init__.py
@@ -2,4 +2,6 @@ from py_v_sdk.api import *
 from py_v_sdk.chain import *
 from py_v_sdk.account import *
 from py_v_sdk.tx_req import *
+from py_v_sdk.contract import *
+from py_v_sdk.contract.nft_ctrt import *
 import py_v_sdk.log


### PR DESCRIPTION
## What Does This PR Do

  - Shorten the import path of the contract.
      - Previously: `py_v_sdk.contract.nft_ctrt.NFTCtrt`
      - Now: `pv.NFTCtrt`