### PR TITLE
🦄 refactor: unify the contract class name to Ctrt

### DIFF
--- a/py_v_sdk/contract/__init__.py
+++ b/py_v_sdk/contract/__init__.py
@@ -158,9 +158,9 @@ class CtrtMeta:
         return b
 
 
-class Contract(abc.ABC):
+class Ctrt(abc.ABC):
     """
-    Contract is the abstract base class for smart contracts
+    Ctrt is the abstract base class for smart contracts
 
     Each contract has a base58 encoded string that contains meta data of the contract.
 

--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -13,19 +13,19 @@ if TYPE_CHECKING:
 from py_v_sdk import data_entry as de
 from py_v_sdk import tx_req as tx
 
-from . import Bytes, CtrtMeta, Contract
+from . import Bytes, CtrtMeta, Ctrt
 
 
-class NFTCtrt(Contract):
+class NFTCtrt(Ctrt):
     """
-    NFTContract is the class that encapsulates behaviours of the VSYS NFT contract V1
+    NFTCtrt is the class that encapsulates behaviours of the VSYS NFT contract V1
     """
 
     CTRT_META = CtrtMeta.from_b58_str(
         "VJodouhmnHVDwtkBZ2NdgahT7NAgNE9EpWoZApzobhpua2nDL9D3sbHSoRRk8bEFeme2BHrXPdcq5VNJcPdGMUD54Smwatyx74cPJyet6bCWmLciHE2jGw9u5TmatjdpFSjGKegh76GvJstK3VaLagvsJJMaaKM9MNXYtgJyDr1Zw7U9PXV7N9TQnSsqz6EHMgDvd8aTDqEG7bxxAotkAgeh4KHqnk6Ga117q5AJctJcbUtD99iUgPmJrC8vzX85TEXgHRY1psW7D6daeExfVVrEPHFHrU6XfhegKv9vRbJBGL861U4Qg6HWbWxbuitgtKoBazSp7VofDtrZebq2NSpZoXCAZC8DRiaysanAqyCJZf7jJ8NfXtWej8L9vg8PVs65MrEmK8toadcyCA2UGzg6pQKrMKQEUahruBiS7zuo62eWwJBxUD1fQ1RGPk9BbMDk9FQQxXu3thSJPnKktq3aJhD9GNFpvyEAaWigp5nfjgH5doVTQk1PgoxeXRAWQNPztjNvZWv6iD85CoZqfCWdJbAXPrWvYW5FsRLW1xJ4ELRUfReMAjCGYuFWdA3CZyefpiDEWqVTe5SA6J6XeUppRyXKpKQTc6upesoAGZZ2NtFDryq22izC6D5p1i98YpC6Dk1qcKevaANKHH8TfFoQT717nrQEY2aLoWrA1ip2t5etdZjNVFmghxXEeCAGy3NcLDFHmAfcBZhHKeJHp8H8HbiMRtWe3wmwKX6mPx16ahnd3dMGCsxAZfjQcy4J1HpuCm7rHMULkixUFYRYqx85c7UpLcijLRybE1MLRjEZ5SEYtazNuiZBwq1KUcNipzrxta9Rpvt2j4WyMadxPf5r9YeAaJJp42PiC6SGfyjHjRQN4K3pohdQRbbG4HQ95NaWCy7CAwbpXRCh9NDMMQ2cmTfB3KFW2M"
     )
 
-    class FuncIdx(Contract.FuncIdx):
+    class FuncIdx(Ctrt.FuncIdx):
         SUPERSEDE = 0
         ISSUE = 1
         SEND = 2

--- a/py_v_sdk/tx_req.py
+++ b/py_v_sdk/tx_req.py
@@ -163,7 +163,7 @@ class ExecCtrtFuncTxReq(TxReq):
     def __init__(
         self,
         ctrt_id: str,
-        func_id: ctrt.Contract.FuncIdx,
+        func_id: ctrt.Ctrt.FuncIdx,
         data_stack: de.DataStack,
         timestamp: de.Timestamp,
         attachment: str = "",
@@ -173,7 +173,7 @@ class ExecCtrtFuncTxReq(TxReq):
         """
         Args:
             ctrt_id (str): The contract id
-            func_id (ctrt.Contract.FuncIdx): The function index
+            func_id (ctrt.Ctrt.FuncIdx): The function index
             data_stack (de.DataStack): The payload of this request
             timestamp (de.Timestamp): The timestamp of this request
             attachment (str, optional): The attachment for this request. Defaults to "".


### PR DESCRIPTION
## What Does This PR Do
Unifies the contract class name to Ctrt

## How Is The Changes Tested
Manually tested against http://veldidina.vos.systems:9928

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
