### PR TITLE
feat: add description param to nft register method

### DIFF
--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -49,12 +49,23 @@ class NFTCtrt(Ctrt):
             return cls(b)
 
     @classmethod
-    def register(cls, by: acnt.Account) -> NFTCtrt:
+    def register(cls, by: acnt.Account, description: str = "") -> NFTCtrt:
+        """
+        register registers an NFT Contract
+
+        Args:
+            by (acnt.Account): The action taker
+            description (str): The description of the action
+
+        Returns:
+            NFTCtrt: The representative instance of the registered Atomic Swap Contract
+        """
         data = by.register_contract(
             tx.RegCtrtTxReq(
                 data_stack=de.DataStack(),
                 ctrt_meta=cls.CTRT_META,
                 timestamp=de.Timestamp.now(),
+                description=description,
             )
         )
         logger.debug(data)


### PR DESCRIPTION
## What Does This PR Do
Adds the `description` param to NFT contract `register` method.

## How Is The Changes Tested
Manually tested against http://veldidina.vos.systems:9928

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
