### PR TITLE
refactor: use ctrt as contract in api wrapper

### DIFF
--- a/py_v_sdk/api.py
+++ b/py_v_sdk/api.py
@@ -93,7 +93,7 @@ class Contract(APIGrp):
     def broadcast_execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         return self.post("/broadcast/execute", payload)
 
-    def get_contract_data(self, ctrt_id: str, db_key: str) -> Dict[str, Any]:
+    def get_ctrt_data(self, ctrt_id: str, db_key: str) -> Dict[str, Any]:
         return self.get(f"/data/{ctrt_id}/{db_key}")
 
 

--- a/py_v_sdk/contract/atomic_swap_ctrt.py
+++ b/py_v_sdk/contract/atomic_swap_ctrt.py
@@ -78,7 +78,7 @@ class AtomicSwapCtrt(Ctrt):
         """
         The address of the maker of this contract
         """
-        data = self.chain.api.ctrt.get_contract_data(
+        data = self.chain.api.ctrt.get_ctrt_data(
             ctrt_id=self.ctrt_id,
             db_key=self.DBKey.for_maker().b58_str,
         )
@@ -90,7 +90,7 @@ class AtomicSwapCtrt(Ctrt):
         """
         The id of the token registered with this contract
         """
-        data = self.chain.api.ctrt.get_contract_data(
+        data = self.chain.api.ctrt.get_ctrt_data(
             ctrt_id=self.ctrt_id,
             db_key=self.DBKey.for_token_id().b58_str,
         )

--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -77,7 +77,7 @@ class NFTCtrt(Ctrt):
 
     @property
     def issuer(self) -> str:
-        data = self.chain.api.ctrt.get_contract_data(
+        data = self.chain.api.ctrt.get_ctrt_data(
             ctrt_id=self.ctrt_id,
             db_key=self.DBKey.for_issuer().b58_str,
         )
@@ -86,7 +86,7 @@ class NFTCtrt(Ctrt):
 
     @property
     def maker(self) -> str:
-        data = self.chain.api.ctrt.get_contract_data(
+        data = self.chain.api.ctrt.get_ctrt_data(
             ctrt_id=self.ctrt_id,
             db_key=self.DBKey.for_maker().b58_str,
         )


### PR DESCRIPTION
## What Does This PR Do
Update name of the method `get_contract_data` to `get_ctrt_data`

## How Is The Changes Tested
Manually tested against http://veldidina.vos.systems:9928

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
