### PR TITLE
test: make wait block time configurable

### DIFF
--- a/test/func_test/conftest.py
+++ b/test/func_test/conftest.py
@@ -7,6 +7,7 @@ import py_v_sdk as pv
 
 HOST = ""
 API_KEY = ""
+SEED = ""
 SUPERNODE_ADDR = ""
 
 

--- a/test/func_test/conftest.py
+++ b/test/func_test/conftest.py
@@ -9,6 +9,7 @@ HOST = ""
 API_KEY = ""
 SEED = ""
 SUPERNODE_ADDR = ""
+AVG_BLOCK_DELAY = 6  # in seconds
 
 
 @pytest.fixture
@@ -77,7 +78,7 @@ async def wait_for_block() -> None:
     """
     wait_for_block waits for the transaction to be packed into a block.
     """
-    await asyncio.sleep(6)
+    await asyncio.sleep(AVG_BLOCK_DELAY)
 
 
 async def assert_tx_success(api: pv.NodeAPI, tx_id: str) -> None:


### PR DESCRIPTION
## What Does This PR Do
Add a global var `AVG_BLOCK_DELAY` to `conftest.py` so that the time to wait in `wait_for_block()` is configurable.

## How Is The Changes Tested
Functional tests passed locally.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
