### PR TITLE
test: add default value for avg block delay

### DIFF
--- a/test/func_test/conftest.py
+++ b/test/func_test/conftest.py
@@ -10,7 +10,7 @@ HOST = os.getenv("PY_SDK_HOST")
 API_KEY = os.getenv("PY_SDK_API_KEY", "")
 SEED = os.getenv("PY_SDK_SEED")
 SUPERNODE_ADDR = os.getenv("PY_SDK_SUPERNODE_ADDR")
-AVG_BLOCK_DELAY = int(os.getenv("PY_SDK_AVG_BLOCK_DELAY"))  # in seconds
+AVG_BLOCK_DELAY = int(os.getenv("PY_SDK_AVG_BLOCK_DELAY", "6"))  # in seconds
 
 
 @pytest.fixture


### PR DESCRIPTION
## What Does This PR Do
Adds the default value for env var `PY_SDK_AVG_BLOCK_DELAY` in the test config.

## How Is The Changes Tested
Tested locally.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
