### PR TITLE
fix: remove redundant lines for DataStack.deserialize

### DIFF
--- a/py_v_sdk/data_entry.py
+++ b/py_v_sdk/data_entry.py
@@ -493,8 +493,6 @@ class DataStack:
         Returns:
             DataStack: The DataStack object created by deserialization.
         """
-        l = struct.unpack(">H", b[:2])[0]
-        b = b[2 : 2 + l]
 
         entries_cnt = struct.unpack(">H", b[:2])[0]
         b = b[2:]


### PR DESCRIPTION
## What Does This PR Do
Remove redundant lines for DataStack.deserialize

## How Is The Changes Tested
Tested locally manually.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
