### PR TITLE
fix: remove the async keyword before the tok_id property

### DIFF
--- a/py_v_sdk/contract/tok_ctrt.py
+++ b/py_v_sdk/contract/tok_ctrt.py
@@ -157,7 +157,7 @@ class TokenCtrtWithoutSplit(Ctrt):
         return data["value"]
 
     @property
-    async def tok_id(self) -> str:
+    def tok_id(self) -> str:
         """
         tok_id returns the token ID of the contract.
 


### PR DESCRIPTION
## What Does This PR Do
Remove the async keyword before the tok_id property in token contract.

## How Is The Changes Tested
No tests are required.

## Checklist

- [ ] Selected assignees
- [ ] Selected reviewers (if you are not the admin of the repo)
- [ ] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
