### PR TITLE
refactor: put NFT v2 whitelist & blacklist to the same inheritance level

### DIFF
--- a/py_v_sdk/contract/nft_ctrt.py
+++ b/py_v_sdk/contract/nft_ctrt.py
@@ -376,14 +376,10 @@ class NFTCtrt(BaseTokCtrt):
         return data
 
 
-class NFTCtrtV2Whitelist(NFTCtrt):
+class NFTCtrtV2Base(NFTCtrt):
     """
-    NFTCtrtV2Whitelist is the class for VSYS NFT contract V2 with whitelist
+    NFTCtrtV2Base is the base class for VSYS NFT contract V2
     """
-
-    CTRT_META = CtrtMeta.from_b58_str(
-        "3g9JzsVg6kPLJKHuWAbMKgiH2aeZt5VTTdrVNeVBQuviDGJnyLrPB4FHtt6Np2rKXy2ZCZftZ1SkNRifVAasWGF5dYt1zagnDrgE52Forq9QyXq2vmyq8NUMVuLfHFDgUC7d7tJPSVZdmhDNzc3cR9WcobXqcR3x923wmTZp63ztxgzdk4cV39TJLoTBLFguFKjqetkU7WUmP6ivMfcvDzMBzgq48fjJ1AYn5fxt31ZV6tAorCQ4w2zfekL8aUEhePgR66RXSBggiqQhTcw7dGg8xkGtRh3wkAVEbFuZa78R1C9cUUytbYM5fi17AE5q9UEgegxMMpZgsk9YNHs4mx4NPLj6Rz5DK3QwbeUbaVWceSqssYS6GodJ41bEm84x3aQrqQK33tHSPRy9uAr9ku773fZuHWPEeNoEDdsnUVsxCKQ7AyM5K1JVFRFwMABGGAnkYsFV23pfLFktBSvAJkzo8Hi6Wss7ZEBgSDeCJJohqoxmsR7L8kcfjRwy3Rb7VU76LMuqGrBfb39uUy5qdxRqAMFtwE4imkxxX6akuR7RMd3RmKQ2W7TXMuWZNyJHd4c17ZJrSCQNAXQ2iKXxSbUoDUmetuCud81SQonTjomq9RsGqRvaV2iGjHUb4wvUuKhodE4dF8xrNWXQxfPpwed1mUEuUPmhppY7Lg7p5EJyXVYDr4ybdsmYohDFgTDbGs3mZBmgUpEVAUC4vJrXqWWv8gjw8j5xabF6QfbtcWrbrVu4sTtMGzybVAoeB4b1x3Rkd67ABWnmzHfDxMopfb21TSDGpWLnSQeRn2gA2jnLUokb8FXUHG5qttmLNzG7RY1XRmC7TKRQ3X5JqGbHbN4rhUxU8iQUKpACWsyGuEP8VrUNvx41sMEbfReZ8ay7v2cQEtmw5uFfXMmAcsQBrRdxsHTaN5Cpu7Ak1pRvZzQKKesWuHLuUgNStdqVpHih4cTk1YzoJJ34spDa7FYhzTWTSVJBwHvYy5WQxrXnXAXBmMeNVroX8x9gT38LeqJ2z4KoAWnj2o1waKB8TC1JXet7sXHttGWDs7YHJHNEy5CcWkVCPnt5xVTq9ZwPkc4EhLQDWortL35e75vyQR3F3tW2Pr89UiPSNWEXxC5L8apavKVyv9zUcWUwShd5bdcfKa1CnLSMhW9DE6CT4APWKuPdxW9hLgkYZziJtN4WebcbA5PbG8hrkhU2E7easz3pRJQ49vhMtSf7tKTf9NDwZuuZ9ix9q5TZMzYvNbg5rk9P6uoPLRZk61J2LpQv8K7YLBrcWSduPsxWWjiCvxL7bW8vA8gWQocxfuXiM5i3wdA1zLx8As3Ydufi2S3nk23BwRjZhjhh7BEq7p1nwpqP97PqqW2CpMJspEHdHCzRR3fBJw6mLdSGAYeia22r2uJm1o73WrPFTt9vQwCLXMKS3WMd3GpRmR36n3C9Ed7xdnFcRDYZBgLis63UEvczGvH9HS8MMHkoAXE3wuahEzYZEd1NxJXSXFhe2h6DJbABXQKMMkZdPQmGJkDhBPTh9nZ9DgGHhnnitxQ5ESfxqvqxwuVubAXTt3psg8LS2B16mjDGh9"
-    )
 
     class FuncIdx(Ctrt.FuncIdx):
         """
@@ -420,20 +416,20 @@ class NFTCtrtV2Whitelist(NFTCtrt):
         """
 
         @classmethod
-        def for_regulator(cls) -> NFTCtrtV2Whitelist.DBKey:
+        def for_regulator(cls) -> NFTCtrtV2Base.DBKey:
             """
             for_regulator returns the DBKey for querying the regulator.
 
             Returns:
-                NFTCtrtV2Whitelist.DBKey: The DBKey.
+                NFTCtrtV2Base.DBKey: The DBKey.
             """
-            b = NFTCtrtV2Whitelist.StateVar.REGULATOR.serialize()
+            b = NFTCtrtV2Base.StateVar.REGULATOR.serialize()
             return cls(b)
 
         @classmethod
         def _for_is_in_list(
             cls, addr_data_entry: Union[de.Addr, de.CtrtAcnt]
-        ) -> NFTCtrtV2Whitelist.DBKey:
+        ) -> NFTCtrtV2Base.DBKey:
             """
             _for_is_in_list returns the DBKey for querying the status of if the address in the given data entry
             is in the list.
@@ -443,35 +439,35 @@ class NFTCtrtV2Whitelist(NFTCtrt):
                 addr_data_entry (Union[de.Addr, de.CtrtAcnt]): The data entry for the address.
 
             Returns:
-                NFTCtrtV2Whitelist.DBKey: The DBKey.
+                NFTCtrtV2Base.DBKey: The DBKey.
             """
-            stmp = NFTCtrtV2Whitelist.StateMap(
-                idx=NFTCtrtV2Whitelist.StateMapIdx.IS_IN_LIST,
+            stmp = NFTCtrtV2Base.StateMap(
+                idx=NFTCtrtV2Base.StateMapIdx.IS_IN_LIST,
                 data_entry=addr_data_entry,
             )
             b = stmp.serialize()
             return cls(b)
 
         @classmethod
-        def for_is_user_in_list(cls, addr: str) -> NFTCtrtV2Whitelist.DBKey:
+        def for_is_user_in_list(cls, addr: str) -> NFTCtrtV2Base.DBKey:
             """
             for_is_user_in_list returns the DBKey for querying the status of if
             the given user address is in the list.
 
             Returns:
-                NFTCtrtV2Whitelist.DBKey: The DBKey.
+                NFTCtrtV2Base.DBKey: The DBKey.
             """
             addr_de = de.Addr(md.Addr(addr))
             return cls._for_is_in_list(addr_de)
 
         @classmethod
-        def for_is_ctrt_in_list(cls, addr: str) -> NFTCtrtV2Whitelist.DBKey:
+        def for_is_ctrt_in_list(cls, addr: str) -> NFTCtrtV2Base.DBKey:
             """
             for_is_ctrt_in_list returns the DBKey for querying the status of if
             the given contract address is in the list.
 
             Returns:
-                NFTCtrtV2Whitelist.DBKey: The DBKey.
+                NFTCtrtV2Base.DBKey: The DBKey.
             """
             addr_de = de.CtrtAcnt(md.CtrtID(addr))
             return cls._for_is_in_list(addr_de)
@@ -487,13 +483,13 @@ class NFTCtrtV2Whitelist(NFTCtrt):
         raw_val = await self._query_db_key(self.DBKey.for_regulator())
         return md.Addr(raw_val)
 
-    async def _is_in_list(self, db_key: NFTCtrtV2Whitelist.DBKey) -> bool:
+    async def _is_in_list(self, db_key: NFTCtrtV2Base.DBKey) -> bool:
         """
         _is_in_list queries & returns the status of whether the address is
         in the list for the given db_key.
 
         Args:
-            db_key (NFTCtrtV2Whitelist.DBKey): The DBKey for the query.
+            db_key (NFTCtrtV2Base.DBKey): The DBKey for the query.
 
         Returns:
             bool: If the address is in the list.
@@ -658,7 +654,17 @@ class NFTCtrtV2Whitelist(NFTCtrt):
         return data
 
 
-class NFTCtrtV2Blacklist(NFTCtrtV2Whitelist):
+class NFTCtrtV2Whitelist(NFTCtrtV2Base):
+    """
+    NFTCtrtV2Whitelist is the class for VSYS NFT contract V2 with whitelist
+    """
+
+    CTRT_META = CtrtMeta.from_b58_str(
+        "3g9JzsVg6kPLJKHuWAbMKgiH2aeZt5VTTdrVNeVBQuviDGJnyLrPB4FHtt6Np2rKXy2ZCZftZ1SkNRifVAasWGF5dYt1zagnDrgE52Forq9QyXq2vmyq8NUMVuLfHFDgUC7d7tJPSVZdmhDNzc3cR9WcobXqcR3x923wmTZp63ztxgzdk4cV39TJLoTBLFguFKjqetkU7WUmP6ivMfcvDzMBzgq48fjJ1AYn5fxt31ZV6tAorCQ4w2zfekL8aUEhePgR66RXSBggiqQhTcw7dGg8xkGtRh3wkAVEbFuZa78R1C9cUUytbYM5fi17AE5q9UEgegxMMpZgsk9YNHs4mx4NPLj6Rz5DK3QwbeUbaVWceSqssYS6GodJ41bEm84x3aQrqQK33tHSPRy9uAr9ku773fZuHWPEeNoEDdsnUVsxCKQ7AyM5K1JVFRFwMABGGAnkYsFV23pfLFktBSvAJkzo8Hi6Wss7ZEBgSDeCJJohqoxmsR7L8kcfjRwy3Rb7VU76LMuqGrBfb39uUy5qdxRqAMFtwE4imkxxX6akuR7RMd3RmKQ2W7TXMuWZNyJHd4c17ZJrSCQNAXQ2iKXxSbUoDUmetuCud81SQonTjomq9RsGqRvaV2iGjHUb4wvUuKhodE4dF8xrNWXQxfPpwed1mUEuUPmhppY7Lg7p5EJyXVYDr4ybdsmYohDFgTDbGs3mZBmgUpEVAUC4vJrXqWWv8gjw8j5xabF6QfbtcWrbrVu4sTtMGzybVAoeB4b1x3Rkd67ABWnmzHfDxMopfb21TSDGpWLnSQeRn2gA2jnLUokb8FXUHG5qttmLNzG7RY1XRmC7TKRQ3X5JqGbHbN4rhUxU8iQUKpACWsyGuEP8VrUNvx41sMEbfReZ8ay7v2cQEtmw5uFfXMmAcsQBrRdxsHTaN5Cpu7Ak1pRvZzQKKesWuHLuUgNStdqVpHih4cTk1YzoJJ34spDa7FYhzTWTSVJBwHvYy5WQxrXnXAXBmMeNVroX8x9gT38LeqJ2z4KoAWnj2o1waKB8TC1JXet7sXHttGWDs7YHJHNEy5CcWkVCPnt5xVTq9ZwPkc4EhLQDWortL35e75vyQR3F3tW2Pr89UiPSNWEXxC5L8apavKVyv9zUcWUwShd5bdcfKa1CnLSMhW9DE6CT4APWKuPdxW9hLgkYZziJtN4WebcbA5PbG8hrkhU2E7easz3pRJQ49vhMtSf7tKTf9NDwZuuZ9ix9q5TZMzYvNbg5rk9P6uoPLRZk61J2LpQv8K7YLBrcWSduPsxWWjiCvxL7bW8vA8gWQocxfuXiM5i3wdA1zLx8As3Ydufi2S3nk23BwRjZhjhh7BEq7p1nwpqP97PqqW2CpMJspEHdHCzRR3fBJw6mLdSGAYeia22r2uJm1o73WrPFTt9vQwCLXMKS3WMd3GpRmR36n3C9Ed7xdnFcRDYZBgLis63UEvczGvH9HS8MMHkoAXE3wuahEzYZEd1NxJXSXFhe2h6DJbABXQKMMkZdPQmGJkDhBPTh9nZ9DgGHhnnitxQ5ESfxqvqxwuVubAXTt3psg8LS2B16mjDGh9"
+    )
+
+
+class NFTCtrtV2Blacklist(NFTCtrtV2Base):
     """
     NFTCtrtV2Blacklist is the class for VSYS NFT contract V2 with blacklist
     """


### PR DESCRIPTION
## What Does This PR Do
put NFT v2 whitelist & blacklist to the same inheritance level

## How Is The Changes Tested
Test cases passed locally.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
