### PR TITLE
fix: fix method name mismatch

### DIFF
--- a/py_v_sdk/contract/atomic_swap_ctrt.py
+++ b/py_v_sdk/contract/atomic_swap_ctrt.py
@@ -467,7 +467,7 @@ class AtomicSwapCtrt(Ctrt):
         Returns:
             Dict[str, Any]: The response returned by the Node API.
         """
-        puzzle_db_key = self.DBKey.for_puzzle(maker_lock_tx_id)
+        puzzle_db_key = self.DBKey.for_swap_puzzle(maker_lock_tx_id)
         data = await self.chain.api.ctrt.get_ctrt_data(
             maker_swap_ctrt_id, puzzle_db_key.b58_str
         )


### PR DESCRIPTION
## What Does This PR Do
Fix method name mismatch

## How Is The Changes Tested
Test cases passed locally.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-v-sdk/blob/develop/doc/dev.md#branch--pr-naming-convention)
